### PR TITLE
ASRE-550: Fix WORKLOAD_API_BEARER_TOKEN issue

### DIFF
--- a/charts/airbyte/templates/secret.yaml
+++ b/charts/airbyte/templates/secret.yaml
@@ -15,4 +15,4 @@ stringData:
   KEYCLOAK_ADMIN_USER: {{ .Values.keycloak.auth.adminUsername | quote }}
   KEYCLOAK_ADMIN_PASSWORD: {{ .Values.keycloak.auth.adminPassword | quote }}
   {{- end }}
-  WORKLOAD_API_BEARER_TOKEN: {{ index ".Values.workload-api.bearerToken" | quote }}
+  WORKLOAD_API_BEARER_TOKEN: {{ index .Values "workload-api-server" "bearerToken" | quote }}


### PR DESCRIPTION
## What
This change updates the WORKLOAD_API_BEARER_TOKEN to use a dynamic value by referencing bearerToken in the workload-api and workload-api-server sections from the Helm values file.

## How
This modification uses Helm's index function to dynamically fetch the bearerToken values from .Values.workload-api and .Values.workload-api-server, ensuring that the correct token is used for authentication. The tokens are now quoted properly for use in Kubernetes configurations.

Before:
WORKLOAD_API_BEARER_TOKEN: {{ index ".Values.workload-api.bearerToken" | quote }}
After:
WORKLOAD_API_BEARER_TOKEN: {{ index .Values "workload-api-server" "bearerToken" | quote }}


## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [ X ] YES 💚
- [ ] NO ❌
