### PR TITLE
ASRE-550: Fix _database/tpl with password and user

### DIFF
--- a/charts/airbyte/templates/_database.tpl
+++ b/charts/airbyte/templates/_database.tpl
@@ -207,11 +207,11 @@ Renders all of the common environment variables which provide database credentia
 Renders a set of database secrets to be included in the shared Airbyte secret
 */}}
 {{- define "airbyte.database.secrets" }}
-{{ $user := (include "airbyte.database.user" .)}}
+{{ $user := (include "airbyte.database.user" .) | trim }}
 {{- if not (empty $user) }}
 DATABASE_USER: {{ $user }}
 {{- end }}
-{{ $password := (include "airbyte.database.password" .)}}
+{{ $password := (include "airbyte.database.password" .) | trim }}
 {{- if not (empty $password) }}
 DATABASE_PASSWORD: {{ $password }}
 {{- end}}


### PR DESCRIPTION
## What
This change updates the airbyte.database.secrets template to trim any leading or trailing whitespace from the user and password values before rendering them. This ensures that no unwanted whitespace is included in the database credentials.

## How
The Helm template is modified to apply the trim function to the user and password values fetched from the airbyte.database.user and airbyte.database.password templates, respectively. This removes any unnecessary whitespace that may have been introduced in the configuration files.

Before:
```
{{- define "airbyte.database.secrets" }}
{{ $user := (include "airbyte.database.user" .)}}
{{- if not (empty $user) }}
DATABASE_USER: {{ $user }}
{{- end }}
{{ $password := (include "airbyte.database.password" .)}}
{{- if not (empty $password) }}
DATABASE_PASSWORD: {{ $password }}
{{- end}}
```
After:
```
{{- define "airbyte.database.secrets" }}
{{ $user := (include "airbyte.database.user" .) | trim }}
{{- if not (empty $user) }}
DATABASE_USER: {{ $user }}
{{- end }}
{{ $password := (include "airbyte.database.password" .) | trim }}
{{- if not (empty $password) }}
DATABASE_PASSWORD: {{ $password }}
{{- end}}
```
This ensures that any extraneous spaces in the DATABASE_USER and DATABASE_PASSWORD values are removed, providing cleaner and more accurate configuration.

## Recommended reading order
1. `airbyte.database.user` template
2. `airbyte.database.password` template

## Can this PR be safely reverted and rolled back?
- [ X ] YES 💚
- [ ] NO ❌
