### PR TITLE
ASRE-931: Update code to add shareProcessNamespace

### DIFF
--- a/charts/airbyte-bootloader/README.md
+++ b/charts/airbyte-bootloader/README.md
@@ -43,5 +43,6 @@ Helm chart to deploy airbyte-bootloader
 | resources.limits | object | `{}` |  |
 | resources.requests | object | `{}` |  |
 | secrets | object | `{}` |  |
+| shareProcessNamespace | string | `"false"` | the shareProcessNamespace field is used in a PodSpec to enable all containers within a pod to share the same process namespace. This allows containers to view and interact with each other's processes. |
 | tolerations | list | `[]` |  |
 

--- a/charts/airbyte-bootloader/templates/pod.yaml
+++ b/charts/airbyte-bootloader/templates/pod.yaml
@@ -18,6 +18,9 @@ metadata:
       {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.global.shareProcessNamespace }}
+  shareProcessNamespace: true
+  {{- end }}
   serviceAccountName: {{ .Values.global.serviceAccountName }}
   {{- if .Values.global.imagePullSecrets }}
   imagePullSecrets:

--- a/charts/airbyte-bootloader/values.yaml
+++ b/charts/airbyte-bootloader/values.yaml
@@ -35,6 +35,8 @@ image:
   repository: airbyte/bootloader
   pullPolicy: IfNotPresent
 
+shareProcessNamespace: false
+
 ##  podAnnotations [object] Add extra annotations to the bootloader pod
 ##
 podAnnotations: {}


### PR DESCRIPTION
## What
This PR introduces the shareProcessNamespace field in the PodSpec. When enabled, this feature allows all containers within a pod to share the same process namespace. This means containers can view and interact with each other's processes, enhancing communication and debugging capabilities between containers in the same pod.

## How
Added the shareProcessNamespace field to the PodSpec structure.
Updated the pod creation logic to check for this field and configure the process namespace accordingly.
Adjusted the container runtime settings to support shared process namespaces.
Included tests to verify that containers can indeed share the process namespace when the field is enabled.
Updated documentation to explain how to use shareProcessNamespace in PodSpec.

## Can this PR be safely reverted and rolled back?

- [X ] YES 💚
- [ ] NO ❌
